### PR TITLE
add kernel traits for dynamic shared memory allocation & code-format

### DIFF
--- a/src/alpaka/HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h
+++ b/src/alpaka/HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h
@@ -198,11 +198,11 @@ namespace alpaka {
     namespace traits {
       //#############################################################################
       //! The trait for getting the size of the block shared dynamic memory for a kernel.
-      template <typename TAcc>
+      template <typename TAcc, typename T>
       struct BlockSharedMemDynSizeBytes<cms::Alpaka::multiBlockPrefixScan, TAcc> {
         //-----------------------------------------------------------------------------
         //! return The size of the shared memory allocated for a block.
-        template <typename T, typename TVec>
+        template <typename TVec>
         ALPAKA_FN_HOST_ACC static auto getBlockSharedMemDynSizeBytes(cms::Alpaka::multiBlockPrefixScan const& kernel,
                                                                      TVec const& blockThreadExtent,
                                                                      TVec const& threadElemExtent,

--- a/src/alpaka/HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h
+++ b/src/alpaka/HeterogeneousCore/AlpakaUtilities/interface/prefixScan.h
@@ -172,7 +172,7 @@ namespace cms {
         // good each block has done its work and now we are left in last block
 
         // let's get the partial sums from each block
-        T* psum = alpaka::block::shared::dyn::getMem<T, 1>(acc);
+        T* psum = alpaka::block::shared::dyn::getMem<T>(acc);
 
         // extern __shared__ T psum[];
         for (int i = blockThreadIdx, ni = gridDimension; i < ni; i += blockDimension) {

--- a/src/alpaka/HeterogeneousCore/AlpakaUtilities/test/prefixScan_t.cc
+++ b/src/alpaka/HeterogeneousCore/AlpakaUtilities/test/prefixScan_t.cc
@@ -212,18 +212,18 @@ int main() {
     // cudaCheck(cudaMalloc(&d_pc, sizeof(int32_t)));
     // cudaCheck(cudaMemset(d_pc, 0, 4));
     // the block counter
-    // auto pc_dBuf = alpaka::mem::buf::alloc<int, Idx>(device, sizeof(int));
-    // int* pc_d = alpaka::mem::view::getPtrNative(pc_dBuf);
-    // alpaka::mem::view::set(queue, pc_dBuf, 0, 4);
+    auto pc_dBuf = alpaka::mem::buf::alloc<int32_t, Idx>(device, Vec::all(sizeof(int32_t)));
+    int32_t* pc_d = alpaka::mem::view::getPtrNative(pc_dBuf);
+    alpaka::mem::view::set(queue, pc_dBuf, 0u, Vec::all(4));
 
-    // nthreads = 512+256;
-    // nblocks = (num_items + nthreads - 1) / nthreads;
-    // std::cout << "launch multiBlockPrefixScan " << num_items <<' '<< nblocks << std::endl;
+    nthreads = 512+256;
+    nblocks = (num_items + nthreads - 1) / nthreads;
+    std::cout << "launch multiBlockPrefixScan " << num_items <<' '<< nblocks << std::endl;
     // // multiBlockPrefixScan<<<nblocks, nthreads, 4*nblocks>>>(input_d, output1_d, num_items, d_pc);
-    // alpaka::queue::enqueue(
-    //       queue,
-    //       alpaka::kernel::createTaskKernel<Acc>({Vec::all(nblocks),Vec::all(nthreads),Vec::all(1)}, multiBlockPrefixScan(), input_d, output1_d, num_items, pc_d);
-    // alpaka::wait::wait(queue);
+    alpaka::queue::enqueue(
+          queue,
+          alpaka::kernel::createTaskKernel<Acc>(WorkDiv{Vec::all(nblocks),Vec::all(nthreads),Vec::all(1)}, multiBlockPrefixScan(), input_d, output1_d, num_items, pc_d));
+    alpaka::wait::wait(queue);
 
 
     // cudaCheck(cudaGetLastError());


### PR DESCRIPTION
- Add the kernel traits for dynamic shared memory allocation
- Replace ``` #pragma unroll ``` with  ``` ALPAKA_UNROLL() ```
- Apply code-format

NOTE: The kernel call still to be fixed! 